### PR TITLE
Fig is deprecated, use docker-compose instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,17 @@ FROM node:0.10-slim
 
 RUN mkdir /home/angular
 
-RUN npm install gulp -g && npm install bower -g
+RUN apt-get -y update \
+    && apt-get install -y \
+        git \
+        bzip2 \
+        libfreetype6 \
+        libfontconfig \
+        python \
+        make \
+        build-essential \
+        && apt-get clean
+RUN npm install gulpjs/gulp-cli#4.0 -g && npm install bower -g
 
 WORKDIR /home/angular
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ $ npm install
 $ gulp
 ```
 
-The docker part is using [fig](http://fig.sh/) so you'll need both docker and fig installed, follow these links to do so: https://docs.docker.com/installation/#installation and http://www.fig.sh/install.html
+The docker part is using [docker-compose](https://docs.docker.com/compose/) so you'll need both docker and docker-compose installed, follow these links to do so: https://docs.docker.com/installation/#installation and https://docs.docker.com/compose/#installation-and-set-up
 
-You can just run fig up and it will set up the environment in a container.
+You can just run `docker-compose up` and it will set up the environment in a container.
 
 ## Structure
 
@@ -99,4 +99,7 @@ $ npm run gulp
 To build the version to distribute, run the following:
 ```bash
 $ npm run gulp build --type dist
+
+# if you are using docker-compose, do it while container is "up"
+$ docker-compose run angular gulp build --type dist
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,4 @@ angular:
         - "./src:/home/angular/src"
     ports:
         - "3000:3000"
+        - "3001:3001"


### PR DESCRIPTION
Fig has been replaced by Docker Compose, and is now deprecated. The new documentation is on the docker website:
http://docs.docker.com/compose/

The default name is now docker-compose.yml